### PR TITLE
Introduce Machinery for Servicing STUN Parameters @ A Semantic Level

### DIFF
--- a/lib/fennec/evaluator.ex
+++ b/lib/fennec/evaluator.ex
@@ -1,9 +1,5 @@
 defmodule Fennec.Evaluator do
-  @moduledoc """
-
-  Common to ALL TURN/STUN. E.g. authentication.
-
-  """
+  @moduledoc false
 
   alias Jerboa.Format, as: Parameters
 

--- a/lib/fennec/evaluator.ex
+++ b/lib/fennec/evaluator.ex
@@ -1,0 +1,23 @@
+defmodule Fennec.Evaluator do
+  @moduledoc """
+
+  Common to ALL TURN/STUN. E.g. authentication.
+
+  """
+
+  alias Jerboa.Format, as: Parameters
+
+  @spec service(Parameters.t, map) :: Parameters.t
+  def service(p, changes) do
+    case class(p) do
+      :request ->
+        Fennec.Evaluator.Request.service(p, changes)
+      _ ->
+        :error
+    end
+  end
+
+  defp class(%Parameters{class: c}) do
+    c
+  end
+end

--- a/lib/fennec/evaluator/binding/request.ex
+++ b/lib/fennec/evaluator/binding/request.ex
@@ -1,0 +1,27 @@
+defmodule Fennec.Evaluator.Binding.Request do
+  @moduledoc false
+
+  alias Jerboa.Format, as: Parameters
+
+  @spec service(Parameters.t, map) :: Parameters.t
+  def service(x, %{address: a, port: p}) do
+    %{x | attributes: [attribute(family(a), a, p)]}
+  end
+
+  defp attribute(f, a, p) do
+    %Jerboa.Format.Body.Attribute.XORMappedAddress{
+      family: f,
+      address: a,
+      port: p
+    }
+  end
+
+  defp family(x) do
+    case tuple_size(x) do
+      4 ->
+        :ipv4
+      8 ->
+        :ipv6
+    end
+  end
+end

--- a/lib/fennec/evaluator/request.ex
+++ b/lib/fennec/evaluator/request.ex
@@ -1,0 +1,51 @@
+defmodule Fennec.Evaluator.Request do
+  @moduledoc """
+
+  Common to ALL REQUESTS. E.g. all requests wind up as a success
+  response OR a failure response.
+
+  """
+
+  alias Jerboa.Format, as: Parameters
+
+  @spec service(Parameters.t, map) :: Parameters.t
+  def service(parameters, changes) do
+    parameters
+    |> service_(changes)
+    |> response
+  end
+
+  def service_(p, changes) do
+    case method(p) do
+      :binding ->
+        Fennec.Evaluator.Binding.Request.service(p, changes)
+      _ ->
+        :error
+    end
+  end
+
+  defp method(%Parameters{method: m}) do
+    m
+  end
+
+  defp response(x) do
+    case errors?(x) do
+      false ->
+        success(x)
+      true ->
+        failure(x)
+    end
+  end
+
+  defp errors?(%Parameters{attributes: _}) do
+    false
+  end
+
+  defp success(x) do
+    %{x | class: :success}
+  end
+
+  defp failure(x) do
+    %{x | class: :failure}
+  end
+end

--- a/lib/fennec/evaluator/request.ex
+++ b/lib/fennec/evaluator/request.ex
@@ -1,10 +1,5 @@
 defmodule Fennec.Evaluator.Request do
-  @moduledoc """
-
-  Common to ALL REQUESTS. E.g. all requests wind up as a success
-  response OR a failure response.
-
-  """
+  @moduledoc false
 
   alias Jerboa.Format, as: Parameters
 

--- a/lib/fennec/stun.ex
+++ b/lib/fennec/stun.ex
@@ -3,44 +3,11 @@ defmodule Fennec.STUN do
   # Processing of STUN messages
 
   alias Jerboa.Format
-  alias Jerboa.Format.Body.Attribute.XORMappedAddress
 
   @spec process_message!(binary, Fennec.ip, Fennec.portn) :: binary | no_return
   def process_message!(data, ip, port) do
-    params = Format.decode!(data)
-    cond do
-      binding_req?(params) ->
-        binding_response(params, ip, port)
-      true ->
-        raise "Unprocessable STUN message"
-    end
-  end
-
-  defp binding_req?(%{class: :request, method: :binding}), do: true
-  defp binding_req?(_), do: false
-
-  defp binding_response(params, ip, port) do
-    xor_mapped_address = build_xor_mapped_address(ip, port)
-    %Format{
-      class: :success,
-      method: :binding,
-      identifier: params.identifier,
-      attributes: [xor_mapped_address],
-    } |> Format.encode()
-  end
-
-  defp build_xor_mapped_address({_, _, _ ,_} = ip4, port) do
-    %XORMappedAddress{
-      family: :ipv4,
-      address: ip4,
-      port: port
-    }
-  end
-  defp build_xor_mapped_address(ip6, port) do
-    %XORMappedAddress{
-      family: :ipv6,
-      address: ip6,
-      port: port
-    }
+    {:ok, x} = Format.decode(data)
+    y = Fennec.Evaluator.service(x, %{address: ip, port: port})
+    Format.encode(y)
   end
 end


### PR DESCRIPTION
A general way to service **all** kinds of STUN message: STUN methods, attributes, and servicing that's applicable to all kinds of STUN message classes can be added easily and understandably.