### PR TITLE
Allow starting servers via app's config

### DIFF
--- a/lib/fennec/application.ex
+++ b/lib/fennec/application.ex
@@ -3,12 +3,24 @@ defmodule Fennec.Application do
 
   use Application
 
+  import Supervisor.Spec
+
   def start(_type, _args) do
-    import Supervisor.Spec, warn: false
-
-    children = []
-
     opts = [strategy: :one_for_one, name: Fennec.Supervisor]
-    Supervisor.start_link(children, opts)
+    Supervisor.start_link(servers(), opts)
   end
+
+  defp servers do
+    :fennec
+    |> Application.get_env(:servers, [])
+    |> Enum.map(&make_server/1)
+  end
+
+  defp make_server({type, config}) do
+    type
+    |> server_mod()
+    |> supervisor([config])
+  end
+
+  defp server_mod(:udp), do: Fennec.UDP
 end

--- a/lib/fennec/udp.ex
+++ b/lib/fennec/udp.ex
@@ -2,8 +2,13 @@ defmodule Fennec.UDP do
   @moduledoc """
   UDP STUN server
 
-  The easiest way to start a server is to hook it up
-  to your supervision tree:
+  The easiest way to start a server is to spawn it under Fennec's
+  supervision tree providing the following configuration:
+
+      config :fennec, :servers,
+        udp: [ip: {192,168, 1, 21}, port: 32323]
+
+  ...or hook it up to your supervision tree:
 
       children = [
         supervisor(Fennec.UDP, [[port: 3478]]),
@@ -13,6 +18,13 @@ defmodule Fennec.UDP do
 
   You can also start a server under Fennec's supervision tree
   using `start/1`.
+
+  ## Options
+
+  All methods of starting a server accept the same configuration options
+  passed as a keyword list:
+  * `:port` - the port which server should be bound to
+  * `:ip` - the address of an interface which server should listen on
 
   You may start multiple UDP servers at a time.
   """


### PR DESCRIPTION
Example:

```elixir
config :fennec, :servers,
  udp: [port: 32123, ip: {127, 0, 0, 1}]
```

Addresses #4