### PR TITLE
Turn allocate

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,1 @@
 use Mix.Config
-
-config :fennec, servers:
-  [udp: []]

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,1 +1,4 @@
 use Mix.Config
+
+config :fennec, servers:
+  [udp: []]

--- a/lib/fennec.ex
+++ b/lib/fennec.ex
@@ -18,4 +18,6 @@ defmodule Fennec do
 
   @type ip :: :inet.ip_address
   @type portn :: :inet.port_number
+
+  @type client_info :: %{ip: Fennec.ip, port: Fennec.portn}
 end

--- a/lib/fennec/evaluator.ex
+++ b/lib/fennec/evaluator.ex
@@ -2,16 +2,15 @@ defmodule Fennec.Evaluator do
   @moduledoc false
 
   alias Jerboa.Params
+  alias Fennec.TURN
 
-  @spec service(Params.t, map, %Fennec.TURN{}) :: Params.t | :void
+  @spec service(Params.t, map, TURN.t) :: {Params.t, TURN.t} | :void
   def service(p, changes, turn_state) do
     case class(p) do
       :request ->
         Fennec.Evaluator.Request.service(p, changes, turn_state)
       :indication ->
         Fennec.Evaluator.Indication.service(p, changes, turn_state)
-      _ ->
-        :error
     end
   end
 

--- a/lib/fennec/evaluator.ex
+++ b/lib/fennec/evaluator.ex
@@ -4,7 +4,8 @@ defmodule Fennec.Evaluator do
   alias Jerboa.Params
   alias Fennec.TURN
 
-  @spec service(Params.t, map, TURN.t) :: {Params.t, TURN.t} | :void
+  @spec service(Params.t, Fennec.client_info, TURN.t)
+    :: {Params.t, TURN.t} | :void
   def service(p, client, turn_state) do
     case class(p) do
       :request ->

--- a/lib/fennec/evaluator.ex
+++ b/lib/fennec/evaluator.ex
@@ -14,7 +14,7 @@ defmodule Fennec.Evaluator do
     end
   end
 
-  defp class(x) do
-    Params.get_class(x)
+  defp class(params) do
+    Params.get_class(params)
   end
 end

--- a/lib/fennec/evaluator.ex
+++ b/lib/fennec/evaluator.ex
@@ -5,12 +5,12 @@ defmodule Fennec.Evaluator do
   alias Fennec.TURN
 
   @spec service(Params.t, map, TURN.t) :: {Params.t, TURN.t} | :void
-  def service(p, changes, turn_state) do
+  def service(p, client, turn_state) do
     case class(p) do
       :request ->
-        Fennec.Evaluator.Request.service(p, changes, turn_state)
+        Fennec.Evaluator.Request.service(p, client, turn_state)
       :indication ->
-        Fennec.Evaluator.Indication.service(p, changes, turn_state)
+        Fennec.Evaluator.Indication.service(p, client, turn_state)
     end
   end
 

--- a/lib/fennec/evaluator.ex
+++ b/lib/fennec/evaluator.ex
@@ -4,14 +4,14 @@ defmodule Fennec.Evaluator do
   alias Jerboa.Params
   alias Fennec.TURN
 
-  @spec service(Params.t, Fennec.client_info, TURN.t)
+  @spec service(Params.t, Fennec.client_info, Fennec.UDP.server_opts, TURN.t)
     :: {Params.t, TURN.t} | :void
-  def service(p, client, turn_state) do
+  def service(p, client, server, turn_state) do
     case class(p) do
       :request ->
-        Fennec.Evaluator.Request.service(p, client, turn_state)
+        Fennec.Evaluator.Request.service(p, client, server, turn_state)
       :indication ->
-        Fennec.Evaluator.Indication.service(p, client, turn_state)
+        Fennec.Evaluator.Indication.service(p, client, server, turn_state)
     end
   end
 

--- a/lib/fennec/evaluator.ex
+++ b/lib/fennec/evaluator.ex
@@ -3,13 +3,13 @@ defmodule Fennec.Evaluator do
 
   alias Jerboa.Params
 
-  @spec service(Params.t, map) :: Params.t | :void
-  def service(p, changes) do
+  @spec service(Params.t, map, %Fennec.TURN{}) :: Params.t | :void
+  def service(p, changes, turn_state) do
     case class(p) do
       :request ->
-        Fennec.Evaluator.Request.service(p, changes)
+        Fennec.Evaluator.Request.service(p, changes, turn_state)
       :indication ->
-        Fennec.Evaluator.Indication.service(p, changes)
+        Fennec.Evaluator.Indication.service(p, changes, turn_state)
       _ ->
         :error
     end

--- a/lib/fennec/evaluator/allocate/request.ex
+++ b/lib/fennec/evaluator/allocate/request.ex
@@ -6,7 +6,7 @@ defmodule Fennec.Evaluator.Allocate.Request do
   alias Fennec.TURN
   @lifetime 10 * 60
 
-  @spec service(Params.t, map, TURN.t) :: {Params.t, TURN.t}
+  @spec service(Params.t, Fennec.client_info, TURN.t) :: {Params.t, TURN.t}
   def service(params, client, turn_state) do
     request_status =
       {:continue, params, %{}}
@@ -23,7 +23,7 @@ defmodule Fennec.Evaluator.Allocate.Request do
     end
   end
 
-  defp allocation_params(params, %{address: a, port: p},
+  defp allocation_params(params, %{ip: a, port: p},
                          turn_state = %TURN{allocation: allocation}) do
     addr = Application.get_env(:fennec, :relay_addr, {127, 0, 0, 1})
     %TURN.Allocation{socket: socket, expire_at: expire_at} = allocation

--- a/lib/fennec/evaluator/allocate/request.ex
+++ b/lib/fennec/evaluator/allocate/request.ex
@@ -101,12 +101,7 @@ defmodule Fennec.Evaluator.Allocate.Request do
   defp maybe({:ok, resp}, _check, _args), do: {:ok, resp}
   defp maybe({:error, error_code}, _check, _x), do: {:error, error_code}
 
-  defp family(params) do
-    case tuple_size(params) do
-      4 ->
-        :ipv4
-      8 ->
-        :ipv6
-    end
-  end
+  defp family(addr) when tuple_size(addr) == 4, do: :ipv4
+  defp family(addr) when tuple_size(addr) == 8, do: :ipv6
+  
 end

--- a/lib/fennec/evaluator/allocate/request.ex
+++ b/lib/fennec/evaluator/allocate/request.ex
@@ -1,0 +1,59 @@
+defmodule Fennec.Evaluator.Allocate.Request do
+  @moduledoc false
+
+  alias Jerboa.Format.Body.Attribute
+  alias Jerboa.Params
+  alias Fennec.TURN
+  @lifetime 10 * 60
+
+  @spec service(Params.t, map, %TURN{}) :: Params.t
+  def service(x, changes, turn_state) do
+    req_id = Params.get_id(x)
+    case turn_state do
+      %TURN{allocation: %TURN.Allocation{owner: ^req_id}} ->
+        {x, turn_state}
+      %TURN{allocation: %TURN.Allocation{}} ->
+        :error
+      %TURN{allocation: nil} ->
+        allocate(x, changes, turn_state)
+    end
+  end
+
+  defp allocate(x, %{address: a, port: p}, turn_state) do
+    {:ok, socket} = :gen_udp.open(0, [:binary, :inet, {:active, true}])
+    {:ok, {addr, port}} = :inet.sockname(socket)
+    allocation = %Fennec.TURN.Allocation{
+      socket: socket,
+      expire_at: System.system_time(:second) + @lifetime,
+      owner: Params.get_id(x)
+    }
+    new_turn_state = %{turn_state | allocation: allocation}
+    attrs = [
+      %Attribute.XORMappedAddress{
+        family: family(a),
+        address: a,
+        port: p
+      },
+      %Attribute.XORRelayedAddress{
+        family: family(addr),
+        address: addr,
+        port: port
+      },
+      %Attribute.Lifetime{
+        duration: @lifetime
+      }
+    ]
+
+    IO.puts inspect attrs
+    {%{x | attributes: attrs}, new_turn_state}
+  end
+
+  defp family(x) do
+    case tuple_size(x) do
+      4 ->
+        :ipv4
+      8 ->
+        :ipv6
+    end
+  end
+end

--- a/lib/fennec/evaluator/allocate/request.ex
+++ b/lib/fennec/evaluator/allocate/request.ex
@@ -6,10 +6,8 @@ defmodule Fennec.Evaluator.Allocate.Request do
   alias Fennec.TURN
   @lifetime 10 * 60
 
-  @spec service(Params.t, map, %TURN{}) :: Params.t
+  @spec service(Params.t, map, TURN.t) :: {Params.t, TURN.t}
   def service(x, changes, turn_state) do
-
-
     request_status =
       {:valid, x, %{}}
       |> maybe(&verify_existing_allocation/4, [changes, turn_state])
@@ -77,12 +75,12 @@ defmodule Fennec.Evaluator.Allocate.Request do
 
   defp verify_requested_transport(x, state) do
     case Params.get_attr(x, Attribute.RequestedTransport) do
-      nil ->
-        {:error, %Attribute.ErrorCode{code: 400}}
       %Attribute.RequestedTransport{protocol: :udp} = t ->
         {:valid, %{x | attributes: x.attributes -- [t]}, state}
-      _ ->
+      %Attribute.RequestedTransport{} ->
         {:error, %Attribute.ErrorCode{code: 437}}
+      _ ->
+        {:error, %Attribute.ErrorCode{code: 400}}
       end
   end
 

--- a/lib/fennec/evaluator/binding/request.ex
+++ b/lib/fennec/evaluator/binding/request.ex
@@ -4,8 +4,8 @@ defmodule Fennec.Evaluator.Binding.Request do
   alias Jerboa.Format
   alias Fennec.TURN
 
-  @spec service(Params.t, map, TURN.t) :: Params.t
-  def service(params, %{address: a, port: p}, _turn_state) do
+  @spec service(Params.t, Fennec.client_info, TURN.t) :: Params.t
+  def service(params, %{ip: a, port: p}, _turn_state) do
     %{params | attributes: [attribute(family(a), a, p)]}
   end
 
@@ -19,5 +19,5 @@ defmodule Fennec.Evaluator.Binding.Request do
 
   defp family(addr) when tuple_size(addr) == 4, do: :ipv4
   defp family(addr) when tuple_size(addr) == 8, do: :ipv6
-  
+
 end

--- a/lib/fennec/evaluator/binding/request.ex
+++ b/lib/fennec/evaluator/binding/request.ex
@@ -5,8 +5,8 @@ defmodule Fennec.Evaluator.Binding.Request do
   alias Fennec.TURN
 
   @spec service(Params.t, map, TURN.t) :: Params.t
-  def service(x, %{address: a, port: p}, _turn_state) do
-    %{x | attributes: [attribute(family(a), a, p)]}
+  def service(params, %{address: a, port: p}, _turn_state) do
+    %{params | attributes: [attribute(family(a), a, p)]}
   end
 
   defp attribute(f, a, p) do
@@ -17,8 +17,8 @@ defmodule Fennec.Evaluator.Binding.Request do
     }
   end
 
-  defp family(x) do
-    case tuple_size(x) do
+  defp family(params) do
+    case tuple_size(params) do
       4 ->
         :ipv4
       8 ->

--- a/lib/fennec/evaluator/binding/request.ex
+++ b/lib/fennec/evaluator/binding/request.ex
@@ -17,12 +17,7 @@ defmodule Fennec.Evaluator.Binding.Request do
     }
   end
 
-  defp family(params) do
-    case tuple_size(params) do
-      4 ->
-        :ipv4
-      8 ->
-        :ipv6
-    end
-  end
+  defp family(addr) when tuple_size(addr) == 4, do: :ipv4
+  defp family(addr) when tuple_size(addr) == 8, do: :ipv6
+  
 end

--- a/lib/fennec/evaluator/binding/request.ex
+++ b/lib/fennec/evaluator/binding/request.ex
@@ -3,8 +3,8 @@ defmodule Fennec.Evaluator.Binding.Request do
 
   alias Jerboa.Format
 
-  @spec service(Params.t, map) :: Params.t
-  def service(x, %{address: a, port: p}) do
+  @spec service(Params.t, map, %Fennec.TURN{}) :: Params.t
+  def service(x, %{address: a, port: p}, _turn_state) do
     %{x | attributes: [attribute(family(a), a, p)]}
   end
 

--- a/lib/fennec/evaluator/binding/request.ex
+++ b/lib/fennec/evaluator/binding/request.ex
@@ -2,8 +2,9 @@ defmodule Fennec.Evaluator.Binding.Request do
   @moduledoc false
 
   alias Jerboa.Format
+  alias Fennec.TURN
 
-  @spec service(Params.t, map, %Fennec.TURN{}) :: Params.t
+  @spec service(Params.t, map, TURN.t) :: Params.t
   def service(x, %{address: a, port: p}, _turn_state) do
     %{x | attributes: [attribute(family(a), a, p)]}
   end

--- a/lib/fennec/evaluator/binding/request.ex
+++ b/lib/fennec/evaluator/binding/request.ex
@@ -4,8 +4,9 @@ defmodule Fennec.Evaluator.Binding.Request do
   alias Jerboa.Format
   alias Fennec.TURN
 
-  @spec service(Params.t, Fennec.client_info, TURN.t) :: Params.t
-  def service(params, %{ip: a, port: p}, _turn_state) do
+  @spec service(Params.t, Fennec.client_info, Fennec.UDP.server_opts, TURN.t)
+    :: Params.t
+  def service(params, %{ip: a, port: p}, _server, _turn_state) do
     %{params | attributes: [attribute(family(a), a, p)]}
   end
 

--- a/lib/fennec/evaluator/indication.ex
+++ b/lib/fennec/evaluator/indication.ex
@@ -2,8 +2,9 @@ defmodule Fennec.Evaluator.Indication do
   @moduledoc false
 
   alias Jerboa.Params
+  alias Fennec.TURN
 
-  @spec service(Params.t, map, %Fennec.TURN{}) :: Params.t | :void
+  @spec service(Params.t, map, TURN.t) :: Params.t | :void
   def service(parameters, _, _turn_state) do
     case method(parameters) do
       :binding ->

--- a/lib/fennec/evaluator/indication.ex
+++ b/lib/fennec/evaluator/indication.ex
@@ -3,17 +3,17 @@ defmodule Fennec.Evaluator.Indication do
 
   alias Jerboa.Params
 
-  @spec service(Params.t, map) :: Params.t | :void
-  def service(parameters, _) do
+  @spec service(Params.t, map, %Fennec.TURN{}) :: Params.t | :void
+  def service(parameters, _, turn_state) do
     case method(parameters) do
       :binding ->
         :void
       _ ->
-        :error
+        {:error, :unsupported_method}
     end
   end
 
-  defp method(%Params{method: m}) do
-    m
+  defp method(x) do
+    Params.get_method(x)
   end
 end

--- a/lib/fennec/evaluator/indication.ex
+++ b/lib/fennec/evaluator/indication.ex
@@ -4,12 +4,10 @@ defmodule Fennec.Evaluator.Indication do
   alias Jerboa.Params
 
   @spec service(Params.t, map, %Fennec.TURN{}) :: Params.t | :void
-  def service(parameters, _, turn_state) do
+  def service(parameters, _, _turn_state) do
     case method(parameters) do
       :binding ->
         :void
-      _ ->
-        {:error, :unsupported_method}
     end
   end
 

--- a/lib/fennec/evaluator/indication.ex
+++ b/lib/fennec/evaluator/indication.ex
@@ -4,7 +4,7 @@ defmodule Fennec.Evaluator.Indication do
   alias Jerboa.Params
   alias Fennec.TURN
 
-  @spec service(Params.t, map, TURN.t) :: Params.t | :void
+  @spec service(Params.t, Fennec.client_info, TURN.t) :: Params.t | :void
   def service(parameters, _, _turn_state) do
     case method(parameters) do
       :binding ->

--- a/lib/fennec/evaluator/indication.ex
+++ b/lib/fennec/evaluator/indication.ex
@@ -12,7 +12,7 @@ defmodule Fennec.Evaluator.Indication do
     end
   end
 
-  defp method(x) do
-    Params.get_method(x)
+  defp method(params) do
+    Params.get_method(params)
   end
 end

--- a/lib/fennec/evaluator/indication.ex
+++ b/lib/fennec/evaluator/indication.ex
@@ -4,8 +4,9 @@ defmodule Fennec.Evaluator.Indication do
   alias Jerboa.Params
   alias Fennec.TURN
 
-  @spec service(Params.t, Fennec.client_info, TURN.t) :: Params.t | :void
-  def service(parameters, _, _turn_state) do
+  @spec service(Params.t, Fennec.client_info, Fennec.UDP.server_opts, TURN.t)
+    :: Params.t | :void
+  def service(parameters, _, _server, _turn_state) do
     case method(parameters) do
       :binding ->
         :void

--- a/lib/fennec/evaluator/request.ex
+++ b/lib/fennec/evaluator/request.ex
@@ -2,13 +2,13 @@ defmodule Fennec.Evaluator.Request do
   @moduledoc false
 
   alias Jerboa.Params
+  alias Jerboa.Format.Body.Attribute
   alias Fennec.TURN
 
   @spec service(Params.t, map, %TURN{}) :: Params.t
   def service(params, changes, turn_state) do
     case service_(params, changes, turn_state) do
       {new_params, new_turn_state} ->
-        IO.puts inspect new_turn_state 
         {response(new_params), new_turn_state}
       new_params ->
         {response(new_params), turn_state}
@@ -37,9 +37,10 @@ defmodule Fennec.Evaluator.Request do
     end
   end
 
-  defp errors?(%Params{attributes: _}), do: false
-  defp errors?(:error), do: true
-
+  defp errors?(%Params{attributes: attrs}) do
+     attrs
+     |> Enum.any? &error_attr?/1
+  end
 
   defp success(x) do
     Params.put_class(x, :success)
@@ -48,4 +49,7 @@ defmodule Fennec.Evaluator.Request do
   defp failure(x) do
     Params.put_class(x, :failure)
   end
+
+  defp error_attr?(%Attribute.ErrorCode{}), do: true
+  defp error_attr?(_), do: false
 end

--- a/lib/fennec/evaluator/request.ex
+++ b/lib/fennec/evaluator/request.ex
@@ -2,20 +2,24 @@ defmodule Fennec.Evaluator.Request do
   @moduledoc false
 
   alias Jerboa.Params
+  alias Fennec.TURN
 
-  @spec service(Params.t, map) :: Params.t
-  def service(parameters, changes) do
-    parameters
-    |> service_(changes)
-    |> response
+  @spec service(Params.t, map, %TURN{}) :: Params.t
+  def service(params, changes, turn_state) do
+    case service_(params, changes, turn_state) do
+      {new_params, new_turn_state} ->
+        {response(new_params), new_turn_state}
+      new_params ->
+        {response(new_params), turn_state}
+    end
   end
 
-  def service_(p, changes) do
+  def service_(p, changes, turn_state) do
     case method(p) do
       :binding ->
-        Fennec.Evaluator.Binding.Request.service(p, changes)
+        Fennec.Evaluator.Binding.Request.service(p, changes, turn_state)
       _ ->
-        :error
+        {:error, :unsupported_method}
     end
   end
 

--- a/lib/fennec/evaluator/request.ex
+++ b/lib/fennec/evaluator/request.ex
@@ -5,9 +5,10 @@ defmodule Fennec.Evaluator.Request do
   alias Jerboa.Format.Body.Attribute
   alias Fennec.TURN
 
-  @spec service(Params.t, Fennec.client_info, TURN.t) :: {Params.t, TURN.t}
-  def service(params, client, turn_state) do
-    case service_(params, client, turn_state) do
+  @spec service(Params.t, Fennec.client_info, Fennec.UDP.server_opts, TURN.t)
+    :: {Params.t, TURN.t}
+  def service(params, client, server, turn_state) do
+    case service_(params, client, server, turn_state) do
       {new_params, new_turn_state} ->
         {response(new_params), new_turn_state}
       new_params ->
@@ -15,12 +16,12 @@ defmodule Fennec.Evaluator.Request do
     end
   end
 
-  defp service_(p, client, turn_state) do
+  defp service_(p, client, server, turn_state) do
     case method(p) do
       :binding ->
-        Fennec.Evaluator.Binding.Request.service(p, client, turn_state)
+        Fennec.Evaluator.Binding.Request.service(p, client, server, turn_state)
       :allocate ->
-        Fennec.Evaluator.Allocate.Request.service(p, client, turn_state)
+        Fennec.Evaluator.Allocate.Request.service(p, client, server, turn_state)
     end
   end
 

--- a/lib/fennec/evaluator/request.ex
+++ b/lib/fennec/evaluator/request.ex
@@ -6,8 +6,8 @@ defmodule Fennec.Evaluator.Request do
   alias Fennec.TURN
 
   @spec service(Params.t, map, TURN.t) :: {Params.t, TURN.t}
-  def service(params, changes, turn_state) do
-    case service_(params, changes, turn_state) do
+  def service(params, client, turn_state) do
+    case service_(params, client, turn_state) do
       {new_params, new_turn_state} ->
         {response(new_params), new_turn_state}
       new_params ->
@@ -15,12 +15,12 @@ defmodule Fennec.Evaluator.Request do
     end
   end
 
-  defp service_(p, changes, turn_state) do
+  defp service_(p, client, turn_state) do
     case method(p) do
       :binding ->
-        Fennec.Evaluator.Binding.Request.service(p, changes, turn_state)
+        Fennec.Evaluator.Binding.Request.service(p, client, turn_state)
       :allocate ->
-        Fennec.Evaluator.Allocate.Request.service(p, changes, turn_state)
+        Fennec.Evaluator.Allocate.Request.service(p, client, turn_state)
     end
   end
 

--- a/lib/fennec/evaluator/request.ex
+++ b/lib/fennec/evaluator/request.ex
@@ -8,6 +8,7 @@ defmodule Fennec.Evaluator.Request do
   def service(params, changes, turn_state) do
     case service_(params, changes, turn_state) do
       {new_params, new_turn_state} ->
+        IO.puts inspect new_turn_state 
         {response(new_params), new_turn_state}
       new_params ->
         {response(new_params), turn_state}
@@ -18,8 +19,8 @@ defmodule Fennec.Evaluator.Request do
     case method(p) do
       :binding ->
         Fennec.Evaluator.Binding.Request.service(p, changes, turn_state)
-      _ ->
-        {:error, :unsupported_method}
+      :allocate ->
+        Fennec.Evaluator.Allocate.Request.service(p, changes, turn_state)
     end
   end
 
@@ -27,18 +28,18 @@ defmodule Fennec.Evaluator.Request do
     Params.get_method(x)
   end
 
-  defp response(x) do
-    case errors?(x) do
+  defp response(result) do
+    case errors?(result) do
       false ->
-        success(x)
+        success(result)
       true ->
-        failure(x)
+        failure(result)
     end
   end
 
-  defp errors?(%Params{attributes: _}) do
-    false
-  end
+  defp errors?(%Params{attributes: _}), do: false
+  defp errors?(:error), do: true
+
 
   defp success(x) do
     Params.put_class(x, :success)

--- a/lib/fennec/evaluator/request.ex
+++ b/lib/fennec/evaluator/request.ex
@@ -5,7 +5,7 @@ defmodule Fennec.Evaluator.Request do
   alias Jerboa.Format.Body.Attribute
   alias Fennec.TURN
 
-  @spec service(Params.t, map, TURN.t) :: {Params.t, TURN.t}
+  @spec service(Params.t, Fennec.client_info, TURN.t) :: {Params.t, TURN.t}
   def service(params, client, turn_state) do
     case service_(params, client, turn_state) do
       {new_params, new_turn_state} ->

--- a/lib/fennec/evaluator/request.ex
+++ b/lib/fennec/evaluator/request.ex
@@ -5,7 +5,7 @@ defmodule Fennec.Evaluator.Request do
   alias Jerboa.Format.Body.Attribute
   alias Fennec.TURN
 
-  @spec service(Params.t, map, %TURN{}) :: Params.t
+  @spec service(Params.t, map, TURN.t) :: {Params.t, TURN.t}
   def service(params, changes, turn_state) do
     case service_(params, changes, turn_state) do
       {new_params, new_turn_state} ->
@@ -15,7 +15,7 @@ defmodule Fennec.Evaluator.Request do
     end
   end
 
-  def service_(p, changes, turn_state) do
+  defp service_(p, changes, turn_state) do
     case method(p) do
       :binding ->
         Fennec.Evaluator.Binding.Request.service(p, changes, turn_state)
@@ -39,7 +39,7 @@ defmodule Fennec.Evaluator.Request do
 
   defp errors?(%Params{attributes: attrs}) do
      attrs
-     |> Enum.any? &error_attr?/1
+     |> Enum.any?(&error_attr?/1)
   end
 
   defp success(x) do

--- a/lib/fennec/evaluator/request.ex
+++ b/lib/fennec/evaluator/request.ex
@@ -24,8 +24,8 @@ defmodule Fennec.Evaluator.Request do
     end
   end
 
-  defp method(x) do
-    Params.get_method(x)
+  defp method(params) do
+    Params.get_method(params)
   end
 
   defp response(result) do
@@ -42,12 +42,12 @@ defmodule Fennec.Evaluator.Request do
      |> Enum.any?(&error_attr?/1)
   end
 
-  defp success(x) do
-    Params.put_class(x, :success)
+  defp success(params) do
+    Params.put_class(params, :success)
   end
 
-  defp failure(x) do
-    Params.put_class(x, :failure)
+  defp failure(params) do
+    Params.put_class(params, :failure)
   end
 
   defp error_attr?(%Attribute.ErrorCode{}), do: true

--- a/lib/fennec/stun.ex
+++ b/lib/fennec/stun.ex
@@ -5,10 +5,9 @@ defmodule Fennec.STUN do
   alias Fennec.TURN
   alias Fennec.Evaluator
 
-  @spec process_message(binary, Fennec.ip, Fennec.portn, TURN.t) ::
-    {:ok, {binary, %TURN{}}} | {:error, term}
-  def process_message(data, ip, port, turn_state) do
-    client = %{address: ip, port: port}
+  @spec process_message(binary, Fennec.client_info, TURN.t) ::
+    {:ok, {binary, %TURN{}}} | {:ok, :void}
+  def process_message(data, client, turn_state) do
     with {:ok, params} <- Jerboa.Format.decode(data),
          {resp, new_turn_state} = Evaluator.service(params, client, turn_state) do
       {:ok, {Jerboa.Format.encode(resp), new_turn_state}}

--- a/lib/fennec/stun.ex
+++ b/lib/fennec/stun.ex
@@ -8,9 +8,9 @@ defmodule Fennec.STUN do
   @spec process_message(binary, Fennec.ip, Fennec.portn, TURN.t) ::
     {:ok, {binary, %TURN{}}} | {:error, term}
   def process_message(data, ip, port, turn_state) do
-    changes = %{address: ip, port: port}
+    client = %{address: ip, port: port}
     with {:ok, params} <- Jerboa.Format.decode(data),
-         {resp, new_turn_state} = Evaluator.service(params, changes, turn_state) do
+         {resp, new_turn_state} = Evaluator.service(params, client, turn_state) do
       {:ok, {Jerboa.Format.encode(resp), new_turn_state}}
     else
       :void ->

--- a/lib/fennec/stun.ex
+++ b/lib/fennec/stun.ex
@@ -8,8 +8,8 @@ defmodule Fennec.STUN do
     {:ok, {binary, %TURN{}}} | {:error, term}
   def process_message(data, ip, port, turn_state) do
     case Jerboa.Format.decode(data) do
-      {:ok, x} ->
-        case Fennec.Evaluator.service(x, %{address: ip, port: port}, turn_state) do
+      {:ok, params} ->
+        case Fennec.Evaluator.service(params, %{address: ip, port: port}, turn_state) do
           :void ->
             {:ok, :void}
           {resp, new_turn_state} when is_map(resp) ->

--- a/lib/fennec/stun.ex
+++ b/lib/fennec/stun.ex
@@ -4,7 +4,7 @@ defmodule Fennec.STUN do
 
   alias Fennec.TURN
 
-  @spec process_message(binary, Fennec.ip, Fennec.portn, %TURN{}) ::
+  @spec process_message(binary, Fennec.ip, Fennec.portn, TURN.t) ::
     {:ok, {binary, %TURN{}}} | {:error, term}
   def process_message(data, ip, port, turn_state) do
     case Jerboa.Format.decode(data) do
@@ -12,8 +12,6 @@ defmodule Fennec.STUN do
         case Fennec.Evaluator.service(x, %{address: ip, port: port}, turn_state) do
           :void ->
             {:ok, :void}
-          {:error, reason} ->
-            {:error, reason}
           {resp, new_turn_state} when is_map(resp) ->
             {:ok, {Jerboa.Format.encode(resp), new_turn_state}}
         end

--- a/lib/fennec/stun.ex
+++ b/lib/fennec/stun.ex
@@ -2,16 +2,23 @@ defmodule Fennec.STUN do
   @moduledoc false
   # Processing of STUN messages
 
-  alias Jerboa.Params
+  alias Fennec.TURN
 
-  @spec process_message!(binary, Fennec.ip, Fennec.portn) :: binary | no_return
-  def process_message!(data, ip, port) do
-    {:ok, x = %Params{method: :binding}} = Jerboa.Format.decode(data)
-    case Fennec.Evaluator.service(x, %{address: ip, port: port}) do
-      :void ->
-        :void
-      y when is_map(y) ->
-        Jerboa.Format.encode(y)
+  @spec process_message(binary, Fennec.ip, Fennec.portn, %TURN{}) ::
+    {:ok, {binary, %TURN{}}} | {:error, term}
+  def process_message(data, ip, port, turn_state) do
+    case Jerboa.Format.decode(data) do
+      {:ok, x} ->
+        case Fennec.Evaluator.service(x, %{address: ip, port: port}, turn_state) do
+          :void ->
+            {:ok, :void}
+          {:error, reason} ->
+            {:error, reason}
+          {resp, new_turn_state} when is_map(resp) ->
+            {:ok, {Jerboa.Format.encode(resp), new_turn_state}}
+        end
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 end

--- a/lib/fennec/stun.ex
+++ b/lib/fennec/stun.ex
@@ -4,12 +4,13 @@ defmodule Fennec.STUN do
 
   alias Fennec.TURN
   alias Fennec.Evaluator
+  alias Fennec.UDP
 
-  @spec process_message(binary, Fennec.client_info, TURN.t) ::
+  @spec process_message(binary, Fennec.client_info, UDP.server_opts, TURN.t) ::
     {:ok, {binary, %TURN{}}} | {:ok, :void}
-  def process_message(data, client, turn_state) do
+  def process_message(data, client, server, turn_state) do
     with {:ok, params} <- Jerboa.Format.decode(data),
-         {resp, new_turn_state} = Evaluator.service(params, client, turn_state) do
+         {resp, new_turn_state} <- Evaluator.service(params, client, server, turn_state) do
       {:ok, {Jerboa.Format.encode(resp), new_turn_state}}
     else
       :void ->

--- a/lib/fennec/turn.ex
+++ b/lib/fennec/turn.ex
@@ -1,0 +1,6 @@
+defmodule Fennec.TURN do
+  @moduledoc false
+
+  defstruct allocation_socket: nil, allocation_time: 0,
+            permissions: [], channels: []
+end

--- a/lib/fennec/turn.ex
+++ b/lib/fennec/turn.ex
@@ -1,6 +1,6 @@
 defmodule Fennec.TURN do
   @moduledoc """
-  This module defines a record used as TURN protocol state.
+  This module defines a struct used as TURN protocol state.
   """
 
   defstruct allocation: nil, permissions: [], channels: []

--- a/lib/fennec/turn.ex
+++ b/lib/fennec/turn.ex
@@ -1,7 +1,13 @@
 defmodule Fennec.TURN do
-  @moduledoc false
+  @moduledoc """
+  This module defines a record used as TURN protocol state.
+  """
 
   defstruct allocation: nil, permissions: [], channels: []
 
-
+  @type t :: %__MODULE__{
+    allocation: nil | Fennec.TURN.Allocation.t,
+    permissions: [],
+    channels: []
+  }
 end

--- a/lib/fennec/turn.ex
+++ b/lib/fennec/turn.ex
@@ -1,6 +1,7 @@
 defmodule Fennec.TURN do
   @moduledoc false
 
-  defstruct allocation_socket: nil, allocation_time: 0,
-            permissions: [], channels: []
+  defstruct allocation: nil, permissions: [], channels: []
+
+
 end

--- a/lib/fennec/turn.ex
+++ b/lib/fennec/turn.ex
@@ -1,7 +1,6 @@
 defmodule Fennec.TURN do
-  @moduledoc """
-  This module defines a struct used as TURN protocol state.
-  """
+  @moduledoc false
+  # This module defines a struct used as TURN protocol state.
 
   defstruct allocation: nil, permissions: [], channels: []
 

--- a/lib/fennec/turn/allocation.ex
+++ b/lib/fennec/turn/allocation.ex
@@ -1,0 +1,3 @@
+defmodule Fennec.TURN.Allocation do
+  defstruct socket: nil, owner: nil, expire_at: 0
+end

--- a/lib/fennec/turn/allocation.ex
+++ b/lib/fennec/turn/allocation.ex
@@ -1,3 +1,14 @@
 defmodule Fennec.TURN.Allocation do
+  @moduledoc """
+  This module defines a record that is used to represent active TURN allocation
+  made by a client.
+  """
+
   defstruct socket: nil, owner: nil, expire_at: 0
+
+  @type t :: %__MODULE__{
+    socket: :gen_udp.socket,
+    owner: binary,
+    expire_at: integer # system time in seconds
+  }
 end

--- a/lib/fennec/turn/allocation.ex
+++ b/lib/fennec/turn/allocation.ex
@@ -1,6 +1,6 @@
 defmodule Fennec.TURN.Allocation do
   @moduledoc """
-  This module defines a record that is used to represent active TURN allocation
+  This module defines a struct that is used to represent active TURN allocation
   made by a client.
   """
 

--- a/lib/fennec/turn/allocation.ex
+++ b/lib/fennec/turn/allocation.ex
@@ -1,8 +1,7 @@
 defmodule Fennec.TURN.Allocation do
-  @moduledoc """
-  This module defines a struct that is used to represent active TURN allocation
-  made by a client.
-  """
+  @moduledoc false
+  # This module defines a struct that is used to represent active TURN allocation
+  # made by a client.
 
   defstruct socket: nil, owner: nil, expire_at: 0
 

--- a/lib/fennec/udp.ex
+++ b/lib/fennec/udp.ex
@@ -111,11 +111,6 @@ defmodule Fennec.UDP do
   end
 
   @doc false
-  def relay_sup_name(base_name) do
-    build_name(base_name, "RelaySupervisor")
-  end
-
-  @doc false
   defp build_name(base, suffix) do
     "#{base}.#{suffix}" |> String.to_atom()
   end

--- a/lib/fennec/udp.ex
+++ b/lib/fennec/udp.ex
@@ -111,6 +111,11 @@ defmodule Fennec.UDP do
   end
 
   @doc false
+  def relay_sup_name(base_name) do
+    build_name(base_name, "RelaySupervisor")
+  end
+
+  @doc false
   defp build_name(base, suffix) do
     "#{base}.#{suffix}" |> String.to_atom()
   end

--- a/lib/fennec/udp.ex
+++ b/lib/fennec/udp.ex
@@ -25,23 +25,25 @@ defmodule Fennec.UDP do
   passed as a keyword list:
   * `:port` - the port which server should be bound to
   * `:ip` - the address of an interface which server should listen on
+  * `:relay_ip` - the address of an interface which relay should listen on
 
   You may start multiple UDP servers at a time.
   """
 
   @type socket :: :gen_udp.socket
-  @type start_options :: [option]
-  @type option :: {:ip, Fennec.ip} | {:port, Fennec.portn}
+  @type server_opts :: [option]
+  @type option :: {:ip, Fennec.ip} | {:port, Fennec.portn} |
+                  {:relay_ip, Fennec.ip}
 
-  @default_opts [ip: {127, 0, 0, 1}, port: 3478]
-  @allowed_opts [:ip, :port]
+  @default_opts [ip: {127, 0, 0, 1}, port: 3478, relay_ip: {127, 0, 0, 1}]
+  @allowed_opts [:ip, :port, :relay_ip]
 
   @doc """
   Starts UDP STUN server under Fennec's supervisor
 
   Accepts the same options as `start_link/1`.
   """
-  @spec start(start_options) :: Supervisor.on_start_child
+  @spec start(server_opts) :: Supervisor.on_start_child
   def start(opts) do
     opts = normalize_opts(opts)
     name = base_name(opts[:port])
@@ -73,7 +75,7 @@ defmodule Fennec.UDP do
 
   Links the server to the calling process.
   """
-  @spec start_link(start_options) :: Supervisor.on_start
+  @spec start_link(server_opts) :: Supervisor.on_start
   def start_link(opts) do
     opts = normalize_opts(opts)
     Fennec.UDP.Supervisor.start_link(opts)

--- a/lib/fennec/udp/receiver.ex
+++ b/lib/fennec/udp/receiver.ex
@@ -8,12 +8,12 @@ defmodule Fennec.UDP.Receiver do
                    worker_sup: atom,
                    socket: Fennec.UDP.socket}
 
-  def start_link(opts, base_name) do
+  def start_link(base_name, opts) do
     name = Fennec.UDP.receiver_name(base_name)
-    GenServer.start_link(__MODULE__, [opts, base_name], name: name)
+    GenServer.start_link(__MODULE__, [base_name, opts], name: name)
   end
 
-  def init([opts, base_name]) do
+  def init([base_name, opts]) do
     worker_sup = Fennec.UDP.worker_sup_name(base_name)
     dispatcher = Fennec.UDP.dispatcher_name(base_name)
     state = %{dispatcher: dispatcher, worker_sup: worker_sup, socket: nil}

--- a/lib/fennec/udp/supervisor.ex
+++ b/lib/fennec/udp/supervisor.ex
@@ -11,8 +11,8 @@ defmodule Fennec.UDP.Supervisor do
 
     children = [
       supervisor(Fennec.UDP.Dispatcher, [base_name]),
-      supervisor(Fennec.UDP.WorkerSupervisor, [base_name]),
-      worker(Fennec.UDP.Receiver, [opts, base_name])
+      supervisor(Fennec.UDP.WorkerSupervisor, [base_name, opts]),
+      worker(Fennec.UDP.Receiver, [base_name, opts])
     ]
 
     opts = [strategy: :one_for_all, name: name]

--- a/lib/fennec/udp/worker.ex
+++ b/lib/fennec/udp/worker.ex
@@ -16,9 +16,9 @@ defmodule Fennec.UDP.Worker do
   # should be configurable
   @timeout 5_000
 
+
   @type state :: %{socket: :gen_udp.socket,
-                   ip: :inet.ip_address,
-                   port: :inet.port_number,
+                   client: Fennec.client_info,
                    turn: TURN.t
                  }
 
@@ -42,19 +42,19 @@ defmodule Fennec.UDP.Worker do
 
   def init([dispatcher, socket, ip, port]) do
     _ = Dispatcher.register_worker(dispatcher, self(), ip, port)
-    {:ok, %{socket: socket, ip: ip, port: port, turn: %TURN{}}}
+    client = %{ip: ip, port: port}
+    {:ok, %{socket: socket, client: client, turn: %TURN{}}}
   end
 
   def handle_cast({:process_data, data}, state) do
     next_state =
-      case Fennec.STUN.process_message(data, state.ip, state.port, state.turn) do
+      case Fennec.STUN.process_message(data, state.client, state.turn) do
         {:ok, :void} ->
           state
         {:ok, {resp, new_turn_state}} ->
-          :ok = :gen_udp.send(state.socket, state.ip, state.port, resp)
+          :ok = :gen_udp.send(state.socket, state.client.ip,
+                              state.client.port, resp)
           %{state | turn: new_turn_state}
-        {:error, _reason} ->
-          state
       end
     {:noreply, next_state, timeout(next_state)}
   end

--- a/lib/fennec/udp/worker.ex
+++ b/lib/fennec/udp/worker.ex
@@ -61,9 +61,10 @@ defmodule Fennec.UDP.Worker do
     {:stop, :normal, state}
   end
 
-  defp timeout(%{turn: %TURN{allocation_socket: nil}}), do: @timeout
-  defp timeout(%{turn: %TURN{allocation_time: refreshed_at}}) do
+  defp timeout(%{turn: %TURN{allocation: nil}}), do: @timeout
+  defp timeout(%{turn: %TURN{allocation: allocation}}) do
+    %TURN.Allocation{expire_at: expire_at} = allocation
     now = System.system_time(:second)
-    now - refreshed_at
+    max(0, expire_at - now) 
   end
 end

--- a/lib/fennec/udp/worker.ex
+++ b/lib/fennec/udp/worker.ex
@@ -19,7 +19,8 @@ defmodule Fennec.UDP.Worker do
   @type state :: %{socket: :gen_udp.socket,
                    ip: :inet.ip_address,
                    port: :inet.port_number,
-                   turn: %TURN{}}
+                   turn: TURN.t
+                 }
 
   # Starts a UDP worker
   @spec start(atom, UDP.socket, Fennec.ip, Fennec.portn) :: {:ok, pid} | :error

--- a/lib/fennec/udp/worker_supervisor.ex
+++ b/lib/fennec/udp/worker_supervisor.ex
@@ -4,14 +4,14 @@ defmodule Fennec.UDP.WorkerSupervisor do
 
   alias Fennec.UDP
 
-  def start_link(base_name) do
+  def start_link(base_name, server_opts) do
     import Supervisor.Spec, warn: false
 
     name = UDP.worker_sup_name(base_name)
     dispatcher = UDP.dispatcher_name(base_name)
 
     children = [
-      worker(Fennec.UDP.Worker, [dispatcher], restart: :temporary)
+      worker(Fennec.UDP.Worker, [dispatcher, server_opts], restart: :temporary)
     ]
 
     opts = [strategy: :simple_one_for_one, name: name]

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Fennec.Mixfile do
      {:dialyxir, "~> 0.4", runtime: false, only: :dev},
      {:excoveralls, "~> 0.5", runtime: false, only: :test},
      {:inch_ex, "~> 0.5", runtime: false, only: :dev},
-     {:jerboa, github: "esl/jerboa", tag: "8998aa1"}]
+     {:jerboa, github: "esl/jerboa", tag: "simple-turn-client"}]
   end
 
   defp package do

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Fennec.Mixfile do
      {:dialyxir, "~> 0.4", runtime: false, only: :dev},
      {:excoveralls, "~> 0.5", runtime: false, only: :test},
      {:inch_ex, "~> 0.5", runtime: false, only: :dev},
-     {:jerboa, "~> 0.1.0"}]
+     {:jerboa, github: "esl/jerboa", tag: "8998aa1"}]
   end
 
   defp package do

--- a/mix.lock
+++ b/mix.lock
@@ -9,7 +9,7 @@
   "hackney": {:hex, :hackney, "1.6.5", "8c025ee397ac94a184b0743c73b33b96465e85f90a02e210e86df6cbafaa5065", [:rebar3], [{:certifi, "0.7.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
   "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
   "inch_ex": {:hex, :inch_ex, "0.5.5", "b63f57e281467bd3456461525fdbc9e158c8edbe603da6e3e4671befde796a3d", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
-  "jerboa": {:git, "https://github.com/esl/jerboa.git", "8998aa11ebde298ad34a887afebcb2178014531f", [tag: "8998aa1"]},
+  "jerboa": {:git, "https://github.com/esl/jerboa.git", "8998aa11ebde298ad34a887afebcb2178014531f", [tag: "simple-turn-client"]},
   "jsx": {:hex, :jsx, "2.8.1", "1453b4eb3615acb3e2cd0a105d27e6761e2ed2e501ac0b390f5bbec497669846", [:mix, :rebar3], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},

--- a/mix.lock
+++ b/mix.lock
@@ -9,7 +9,7 @@
   "hackney": {:hex, :hackney, "1.6.5", "8c025ee397ac94a184b0743c73b33b96465e85f90a02e210e86df6cbafaa5065", [:rebar3], [{:certifi, "0.7.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
   "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
   "inch_ex": {:hex, :inch_ex, "0.5.5", "b63f57e281467bd3456461525fdbc9e158c8edbe603da6e3e4671befde796a3d", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
-  "jerboa": {:hex, :jerboa, "0.1.0", "bfa846884d748e1b859f21acf1d83f0b881146e1f13ff4a77f66dd947a32ce00", [:mix], []},
+  "jerboa": {:git, "https://github.com/esl/jerboa.git", "8998aa11ebde298ad34a887afebcb2178014531f", [tag: "8998aa1"]},
   "jsx": {:hex, :jsx, "2.8.1", "1453b4eb3615acb3e2cd0a105d27e6761e2ed2e501ac0b390f5bbec497669846", [:mix, :rebar3], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},

--- a/test/fennec/udp_test.exs
+++ b/test/fennec/udp_test.exs
@@ -186,7 +186,8 @@ defmodule Fennec.UDPTest do
   defp udp_connect(server_address, server_port, client_address, client_port,
                    client_count) do
     Application.put_env(:fennec, :relay_addr, server_address)
-    Fennec.UDP.start_link(ip: server_address, port: server_port)
+    Fennec.UDP.start_link(ip: server_address, port: server_port,
+                          relay_ip: server_address)
 
     sockets =
       for i <- 1..client_count do

--- a/test/fennec/udp_test.exs
+++ b/test/fennec/udp_test.exs
@@ -3,7 +3,6 @@ defmodule Fennec.UDPTest do
 
   alias Jerboa.Params
   alias Jerboa.Format
-  alias Jerboa.Format.Body.Attribute
   alias Jerboa.Format.Body.Attribute.XORMappedAddress
 
   @recv_timeout 5000
@@ -33,10 +32,9 @@ defmodule Fennec.UDPTest do
                      method: :binding,
                      identifier: ^id,
                      attributes: [a]} = params
-      assert %Attribute{name: XORMappedAddress, value: v} = a
       assert %XORMappedAddress{address: ^client_address,
                                port: ^client_port,
-                               family: :ipv6} = v
+                               family: :ipv6} = a
     end
   end
 

--- a/test/fennec/udp_test.exs
+++ b/test/fennec/udp_test.exs
@@ -3,7 +3,8 @@ defmodule Fennec.UDPTest do
 
   alias Jerboa.Params
   alias Jerboa.Format
-  alias Jerboa.Format.Body.Attribute.XORMappedAddress
+  alias Jerboa.Format.Body.Attribute.{XORMappedAddress, Lifetime,
+                                      XORRelayedAddress, ErrorCode}
 
   @recv_timeout 5000
 
@@ -38,6 +39,124 @@ defmodule Fennec.UDPTest do
     end
   end
 
+  describe "allocate request" do
+
+    test "returns response with IPv6 XOR relayed address attribute" do
+      server_port = 12_122
+      server_address = {0, 0, 0, 0, 0, 0, 0, 1}
+      client_port = 43_435
+      client_address = {0, 0, 0, 0, 0, 0, 0, 1}
+      Application.put_env(:fennec, :relay_addr, server_address)
+
+      Fennec.UDP.start_link(ip: server_address, port: server_port)
+      id = :crypto.strong_rand_bytes(12)
+      req = allocate_request(id)
+
+      {:ok, sock} = :gen_udp.open(client_port,
+                                  [:binary, active: false, ip: client_address])
+      :ok = :gen_udp.send(sock, server_address, server_port, req)
+
+      assert {:ok,
+              {^server_address,
+               ^server_port,
+               resp}} = :gen_udp.recv(sock, 0, @recv_timeout)
+      :gen_udp.close(sock)
+      params = Format.decode!(resp)
+      assert %Params{class: :success,
+                     method: :allocate,
+                     identifier: ^id,
+                     attributes: attrs} = params
+      [lifetime, mapped, relayed] = Enum.sort(attrs)
+
+      assert %Lifetime{duration: 600} = lifetime
+
+      assert %XORMappedAddress{address: ^client_address,
+                               port: ^client_port,
+                               family: :ipv6} = mapped
+
+      assert %XORRelayedAddress{address: ^server_address,
+                                port: relayed_port,
+                                family: :ipv6} = relayed
+      assert relayed_port != server_port
+    end
+
+    test "returns error after second allocation" do
+      server_port = 12_123
+      server_address = {127, 0, 0, 1}
+      client_port = 43_436
+      client_address = {127, 0, 0, 1}
+      Application.put_env(:fennec, :relay_addr, server_address)
+
+      Fennec.UDP.start_link(ip: server_address, port: server_port)
+      id1 = :crypto.strong_rand_bytes(12)
+      id2 = :crypto.strong_rand_bytes(12)
+      req1 = allocate_request(id1)
+      req2 = allocate_request(id2)
+
+      {:ok, sock} = :gen_udp.open(client_port,
+                                  [:binary, active: false, ip: client_address])
+
+      :ok = :gen_udp.send(sock, server_address, server_port, req1)
+      assert {:ok,
+              {^server_address,
+               ^server_port,
+               _resp}} = :gen_udp.recv(sock, 0, @recv_timeout)
+
+      :ok = :gen_udp.send(sock, server_address, server_port, req2)
+      assert {:ok,
+              {^server_address,
+               ^server_port,
+               resp}} = :gen_udp.recv(sock, 0, @recv_timeout)
+
+
+      :gen_udp.close(sock)
+      params = Format.decode!(resp)
+      assert %Params{class: :failure,
+                     method: :allocate,
+                     identifier: ^id2,
+                     attributes: [error]} = params
+      assert %ErrorCode{code: 437} = error
+    end
+
+    test "returns success after redundant allocation" do
+      server_port = 12_125
+      server_address = {127, 0, 0, 1}
+      client_port = 43_437
+      client_address = {127, 0, 0, 1}
+      Application.put_env(:fennec, :relay_addr, server_address)
+
+      Fennec.UDP.start_link(ip: server_address, port: server_port)
+      id = :crypto.strong_rand_bytes(12)
+      req = allocate_request(id)
+
+      {:ok, sock} = :gen_udp.open(client_port,
+                                  [:binary, active: false, ip: client_address])
+
+      :ok = :gen_udp.send(sock, server_address, server_port, req)
+      assert {:ok,
+              {^server_address,
+               ^server_port,
+               _resp}} = :gen_udp.recv(sock, 0, @recv_timeout)
+
+      :ok = :gen_udp.send(sock, server_address, server_port, req)
+      assert {:ok,
+              {^server_address,
+               ^server_port,
+               resp}} = :gen_udp.recv(sock, 0, @recv_timeout)
+
+
+      :gen_udp.close(sock)
+      params = Format.decode!(resp)
+      assert %Params{class: :success,
+                     method: :allocate,
+                     identifier: ^id,
+                     attributes: attrs} = params
+      assert 3 = length(attrs)
+    end
+  end
+
+
+
   test "start/1 and stop/1 a UDP server linked to Fennec.Supervisor" do
     port = 23_232
     {:ok, _} = Fennec.UDP.start(ip: {127, 0, 0, 1}, port: port)
@@ -53,5 +172,9 @@ defmodule Fennec.UDPTest do
 
   defp binding_indication(id) do
     %Params{class: :indication, method: :binding, identifier: id} |> Format.encode()
+  end
+
+  defp allocate_request(id) do
+    %Params{class: :request, method: :allocate, identifier: id} |> Format.encode()
   end
 end

--- a/test/fennec/udp_test.exs
+++ b/test/fennec/udp_test.exs
@@ -159,7 +159,8 @@ defmodule Fennec.UDPTest do
     port = 23_232
     {:ok, _} = Fennec.UDP.start(ip: {127, 0, 0, 1}, port: port)
 
-    assert [{:"Elixir.Fennec.UDP.23232", _, _, _}] = Supervisor.which_children(Fennec.Supervisor)
+    assert [{:"Elixir.Fennec.UDP.23232", _, _, _}] =
+      Supervisor.which_children(Fennec.Supervisor)
     assert :ok = Fennec.UDP.stop(port)
     assert [] = Supervisor.which_children(Fennec.Supervisor)
   end

--- a/test/fennec/udp_test.exs
+++ b/test/fennec/udp_test.exs
@@ -43,8 +43,8 @@ defmodule Fennec.UDPTest do
   describe "allocate request" do
 
     setup ctx do
-      test_case_id = Map.get(ctx, :test_case_id, 0)
-      port_mod = test_case_id * 100
+      test_case_id = ctx.line
+      port_mod = test_case_id * 10
       udp =
         udp_connect({0, 0, 0, 0, 0, 0, 0, 1}, 12_100 + port_mod,
                     {0, 0, 0, 0, 0, 0, 0, 1}, 42_100 + port_mod, 1)
@@ -52,7 +52,7 @@ defmodule Fennec.UDPTest do
         udp_close(udp)
       end
 
-      {:ok, [udp: udp, test_case_id: test_case_id + 1]}
+      {:ok, [udp: udp]}
     end
 
     test "fails without RequestedTransport attribute", ctx do

--- a/test/fennec_test.exs
+++ b/test/fennec_test.exs
@@ -7,9 +7,9 @@ defmodule FennecTest do
 
     ## Given:
     import Fennec.Test.Helper.Server, only: [configuration: 1]
-    cfg = %{address: a, port: p} = configuration("Fennec (local)")
+    %{address: a, port: p} = configuration("Fennec (local)")
     Fennec.UDP.start_link(ip: a, port: p)
-    {:ok, alice} = Jerboa.Client.start(server: cfg)
+    {:ok, alice} = Jerboa.Client.start(server: {a, p})
     on_exit fn ->
       :ok = Jerboa.Client.stop(alice)
     end
@@ -40,9 +40,9 @@ defmodule FennecTest do
     end
   end
 
-  defp family({address, _}) when tuple_size(address) == 4 do
-    "IPv4"
-  end
+  defp family({:ok, {address, _}}) when tuple_size(address) == 4, do: "IPv4"
+  defp family({:ok, {address, _}}) when tuple_size(address) == 8, do: "IPv6"
+  defp family(_), do: "unknown"
 
   defp ok?(x) do
     x == :ok

--- a/test/fennec_test.exs
+++ b/test/fennec_test.exs
@@ -19,6 +19,15 @@ defmodule FennecTest do
 
   describe "(IPv4) Fennec over UDP Transport" do
 
+    test "send allocate request; recieve success response", %{client: alice} do
+
+      ## When:
+      x = Jerboa.Client.allocate(alice)
+    
+      ## Then:
+      assert family(x) == "IPv4"
+    end
+
     test "send binding request; recieve success response", %{client: alice} do
 
       ## When:
@@ -42,7 +51,7 @@ defmodule FennecTest do
 
   defp family({:ok, {address, _}}) when tuple_size(address) == 4, do: "IPv4"
   defp family({:ok, {address, _}}) when tuple_size(address) == 8, do: "IPv6"
-  defp family(_), do: "unknown"
+  defp family(r), do: r
 
   defp ok?(x) do
     x == :ok

--- a/test/fennec_test.exs
+++ b/test/fennec_test.exs
@@ -23,7 +23,7 @@ defmodule FennecTest do
 
       ## When:
       x = Jerboa.Client.allocate(alice)
-    
+
       ## Then:
       assert family(x) == "IPv4"
     end


### PR DESCRIPTION
This PR introduces initial, minimal implementation of TURN Allocate request. Please note that this implementation *is not* fully compliant with the RFC in order to make it possible to work on other TURN features ASAP. Making this code fully RFC compliant can done in another PR.  

This PR is blocked by esl/jerboa#80 and esl/jerboa#68. 
The further implementation of this request is also block until `jerboa` introduces support for the following attributes: `DONT-FRAGMENT`, `RESERVATION-TOKEN`, `EVEN-PORT`