### PR TITLE
Improve tests reliability

### DIFF
--- a/test/fennec/udp/allocate_test.exs
+++ b/test/fennec/udp/allocate_test.exs
@@ -11,12 +11,9 @@ defmodule Fennec.UDP.AllocateTest do
 
   describe "allocate request" do
 
-    setup ctx do
-      test_case_id = ctx.line
-      port_mod = test_case_id * 10
+    setup do
       udp =
-        UDP.connect({0, 0, 0, 0, 0, 0, 0, 1}, 12_100 + port_mod,
-                    {0, 0, 0, 0, 0, 0, 0, 1}, 42_100 + port_mod, 1)
+        UDP.connect({0, 0, 0, 0, 0, 0, 0, 1}, {0, 0, 0, 0, 0, 0, 0, 1}, 1)
       on_exit fn ->
         UDP.close(udp)
       end

--- a/test/fennec/udp/auth_template.ex
+++ b/test/fennec/udp/auth_template.ex
@@ -23,11 +23,10 @@ defmodule Fennec.UDP.AuthTemplate do
                                           RequestedTransport, Nonce, Realm}
 
       describe unquote(request_str) <> " request" do
-        setup ctx do
+        setup do
           Application.put_env(:fennec, :secret, @valid_secret)
           udp =
-            UDP.connect({0, 0, 0, 0, 0, 0, 0, 1}, :crypto.rand_uniform(12_000, 35_000),
-                        {0, 0, 0, 0, 0, 0, 0, 1}, :crypto.rand_uniform(35_000, 65_000), 1)
+            UDP.connect({0, 0, 0, 0, 0, 0, 0, 1}, {0, 0, 0, 0, 0, 0, 0, 1}, 1)
           on_exit fn ->
             UDP.close(udp)
           end

--- a/test/fennec/udp/binding_test.exs
+++ b/test/fennec/udp/binding_test.exs
@@ -1,33 +1,33 @@
 defmodule Fennec.UDP.BindingTest do
   use ExUnit.Case
-  import Helper.UDP
 
+  alias Helper.UDP
   alias Jerboa.Params
   alias Jerboa.Format
   alias Jerboa.Format.Body.Attribute.XORMappedAddress
 
-  @recv_timeout 5_000
-
   describe "binding request" do
 
-    test "returns response with IPv6 XOR mapped address attribute" do
-      server_port = 13_100
-      server_address = {0, 0, 0, 0, 0, 0, 0, 1}
-      client_port = 43_100
-      client_address = {0, 0, 0, 0, 0, 0, 0, 1}
-      Fennec.UDP.start_link(ip: server_address, port: server_port)
+    setup do
+      udp =
+        UDP.connect({0, 0, 0, 0, 0, 0, 0, 1}, {0, 0, 0, 0, 0, 0, 0, 1}, 1)
+      on_exit fn ->
+        UDP.close(udp)
+      end
+
+      {:ok, [udp: udp]}
+    end
+
+    test "returns response with IPv6 XOR mapped address attribute", ctx do
+      udp = ctx.udp
+      client_address = udp.client_address
+      client_port = UDP.client_port(udp, 0)
+
       id = Params.generate_id()
-      req = binding_request(id)
+      req = UDP.binding_request(id)
 
-      {:ok, sock} = :gen_udp.open(client_port,
-                                  [:binary, active: false, ip: client_address])
-      :ok = :gen_udp.send(sock, server_address, server_port, req)
+      resp = UDP.communicate(udp, 0, req)
 
-      assert {:ok,
-              {^server_address,
-               ^server_port,
-               resp}} = :gen_udp.recv(sock, 0, @recv_timeout)
-      :gen_udp.close(sock)
       params = Format.decode!(resp)
       assert %Params{class: :success,
                      method: :binding,

--- a/test/fennec/udp/create_permission_test.exs
+++ b/test/fennec/udp/create_permission_test.exs
@@ -9,12 +9,9 @@ defmodule Fennec.UDP.CreatePermissionTest do
   alias Jerboa.Format.Body.Attribute.{ErrorCode, XORRelayedAddress}
   alias Fennec.UDP.Worker
 
-  setup ctx do
-    test_case_id = ctx.line
-    port_mod = test_case_id * 10
+  setup do
     udp =
-      UDP.connect({127, 0, 0, 1}, 12_100 + port_mod,
-                  {127, 0, 0, 1}, 42_100 + port_mod, 2)
+      UDP.connect({127, 0, 0, 1}, {127, 0, 0, 1}, 2)
     on_exit fn ->
       UDP.close(udp)
     end

--- a/test/fennec/udp/server_test.exs
+++ b/test/fennec/udp/server_test.exs
@@ -2,10 +2,11 @@ defmodule Fennec.UDP.ServerTest do
   use ExUnit.Case
 
   test "start/1 and stop/1 a UDP server linked to Fennec.Supervisor" do
-    port = 23_232
+    port = Helper.PortMaster.checkout_port(:server)
     {:ok, _} = Fennec.UDP.start(ip: {127, 0, 0, 1}, port: port)
 
-    assert [{:"Elixir.Fennec.UDP.23232", _, _, _}] =
+    expected_name = String.to_atom(~s"Elixir.Fennec.UDP.#{port}")
+    assert [{^expected_name, _, _, _}] =
       Supervisor.which_children(Fennec.Supervisor)
     assert :ok = Fennec.UDP.stop(port)
     assert [] = Supervisor.which_children(Fennec.Supervisor)

--- a/test/helper/macros.ex
+++ b/test/helper/macros.ex
@@ -1,5 +1,5 @@
 defmodule Helper.Macros do
-  defmacro __using__(opts) do
+  defmacro __using__(_opts) do
     quote do
       @eventually_timeout 5_000
       defmacro eventually(truly) do

--- a/test/helper/port_master.ex
+++ b/test/helper/port_master.ex
@@ -1,0 +1,33 @@
+defmodule Helper.PortMaster do
+  use GenServer
+
+  @base_client_port 32_000
+  @base_server_port 12_000
+  @server_name :port_master
+
+  def start_link do
+    GenServer.start_link(__MODULE__, [], name: @server_name)
+  end
+
+  def checkout_port(type) do
+    GenServer.call(@server_name, {:checkout_port, type})
+  end
+
+  def init(_opts) do
+    {:ok, %{
+      next_client: @base_client_port,
+      next_server: @base_server_port
+    }}
+  end
+
+  def handle_call({:checkout_port, :client}, _from, state) do
+    new_state = %{state | next_client: state.next_client + 1}
+    {:reply, state.next_client, new_state}
+  end
+
+  def handle_call({:checkout_port, :server}, _from, state) do
+    new_state = %{state | next_server: state.next_server + 1}
+    {:reply, state.next_server, new_state}
+  end
+
+end

--- a/test/helper/udp.ex
+++ b/test/helper/udp.ex
@@ -84,8 +84,9 @@ defmodule Helper.UDP do
 
   ## Communication
 
-  def connect(server_address, server_port, client_address, client_port,
-                   client_count) do
+  def connect(server_address, client_address, client_count) do
+    server_port = Helper.PortMaster.checkout_port(:server)
+    client_port = Helper.PortMaster.checkout_port(:client)
     Application.put_env(:fennec, :relay_addr, server_address)
     Fennec.UDP.start_link(ip: server_address, port: server_port,
                           relay_ip: server_address)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -8,3 +8,5 @@ Enum.each files, fn(file) ->
 end
 
 Code.require_file "fennec/udp/auth_template.ex", __DIR__
+
+{:ok, _pid} = Helper.PortMaster.start_link()


### PR DESCRIPTION
This PR fixes most of the issues with randomly failing tests. 
1. All tests use `Helper.UDP.connect` to initialize client-server connections
2. The `Helper.UDP.connect` uses central, single process to checkout ports through `Helper.PortMaster` module. 

There still are some problems with timeouts but those seem to be a problem of `jerboa's` client. Also, there may could be port clash with other services that happens to allocate the same port, but to mitigate this problem we would need to checkout atomically the whole socket, which is in server's case simply impossible. 

