### PR TITLE
Avoid :eaddrinuse in Travis tests

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,10 +1,1 @@
 use Mix.Config
-
-config :jerboa, :test,
-  server: [%{name: "Google (remote)",
-             address: {74, 125, 143, 127},
-             port: 19_302},
-           %{name: "Fennec (local)",
-             address: {127, 0, 0, 1},
-             port: 8_192}
-          ]

--- a/test/fennec/udp/data_test.exs
+++ b/test/fennec/udp/data_test.exs
@@ -59,8 +59,7 @@ defmodule Fennec.UDP.DataTest do
       raw = UDP.recv(ctx.udp, _client_id = 0)
       params = Format.decode!(raw)
       assert %Params{class: :indication,
-                     method: :data,
-                     attributes: attrs} = params
+                     method: :data} = params
       assert %XORPeerAddress{address: @peer_addr,
                              port: peer_port,
                              family: :ipv4} == Params.get_attr(params, XORPeerAddress)

--- a/test/fennec_test.exs
+++ b/test/fennec_test.exs
@@ -1,16 +1,20 @@
 defmodule FennecTest do
   use ExUnit.Case, async: true
 
+  alias Helper.PortMaster
+
   @moduletag :system
+  @server_addr {127, 0, 0, 1}
 
   setup do
 
     ## Given:
     import Fennec.Test.Helper.Server, only: [configuration: 1]
-    %{address: a, port: p} = configuration("Fennec (local)")
-    Fennec.UDP.start_link(ip: a, port: p)
+    port = PortMaster.checkout_port(:server)
+    Fennec.UDP.start_link(ip: @server_addr, port: port)
     Application.put_env(:fennec, :secret, "abc")
-    {:ok, alice} = Jerboa.Client.start(server: {a, p}, username: "alice", secret: "abc")
+    {:ok, alice} = Jerboa.Client.start(server: {@server_addr, port},
+                                       username: "alice", secret: "abc")
     on_exit fn ->
       :ok = Jerboa.Client.stop(alice)
     end


### PR DESCRIPTION
The hypothesis is that the OS doesn't allow opening a listening UDP socket multiple times on the same port. This could happen if the Receiver was stopped asynchronously and wouldn't shutdown and close its socket before a new test started.

Let's see if this change helps.