### PR TITLE
Allocate reserved relay address

### DIFF
--- a/lib/fennec.ex
+++ b/lib/fennec.ex
@@ -19,5 +19,6 @@ defmodule Fennec do
   @type ip :: :inet.ip_address
   @type portn :: :inet.port_number
 
-  @type client_info :: %{ip: Fennec.ip, port: Fennec.portn}
+  @type client_info :: %{socket: Fennec.UDP.socket,
+                         ip: Fennec.ip, port: Fennec.portn}
 end

--- a/lib/fennec/application.ex
+++ b/lib/fennec/application.ex
@@ -5,7 +5,7 @@ defmodule Fennec.Application do
 
   def start(_type, _args) do
     opts = [strategy: :one_for_one, name: Fennec.Supervisor]
-    Supervisor.start_link(servers(), opts)
+    Supervisor.start_link([Fennec.ReservationLog.child_spec()] ++ servers(), opts)
   end
 
   defp servers do

--- a/lib/fennec/evaluator/allocate/request.ex
+++ b/lib/fennec/evaluator/allocate/request.ex
@@ -241,9 +241,4 @@ defmodule Fennec.Evaluator.Allocate.Request do
     end
   end
 
-  defp rlog(server) do
-    base_name = Fennec.UDP.base_name(server[:port])
-    Fennec.ReservationLog.name(base_name)
-  end
-
 end

--- a/lib/fennec/evaluator/allocate/request.ex
+++ b/lib/fennec/evaluator/allocate/request.ex
@@ -10,6 +10,7 @@ defmodule Fennec.Evaluator.Allocate.Request do
   alias Jerboa.Format.Body.Attribute.ErrorCode
   alias Jerboa.Params
   alias Fennec.TURN
+  alias Fennec.TURN.Reservation
 
   require Integer
 
@@ -146,8 +147,8 @@ defmodule Fennec.Evaluator.Allocate.Request do
   defp do_reserve_another_relay(params, state, client, server, socket) do
     alias Fennec.UDP
     worker_sup = UDP.worker_sup_name(UDP.base_name(server[:port]))
-    {:ok, _} = UDP.Worker.start(worker_sup, client)
-    #reservation = Reservation.new(socket)
+    {:ok, new_relay} = UDP.Worker.start(worker_sup, client)
+    r = Reservation.new(socket)
     :erlang.error(:"not implemented yet")
   end
 

--- a/lib/fennec/evaluator/allocate/request.ex
+++ b/lib/fennec/evaluator/allocate/request.ex
@@ -123,7 +123,7 @@ defmodule Fennec.Evaluator.Allocate.Request do
     Logger.warn(:max_retries)
     {:error, ErrorCode.new(:insufficient_capacity)}
   end
-  defp open_this_relay( params, state, server) do
+  defp open_this_relay(params, state, server) do
     opts = udp_opts(server)
     case {Params.get_attr(params, Attribute.EvenPort),
           :gen_udp.open(0, opts)} do

--- a/lib/fennec/evaluator/allocate/request.ex
+++ b/lib/fennec/evaluator/allocate/request.ex
@@ -138,6 +138,7 @@ defmodule Fennec.Evaluator.Allocate.Request do
     rlog = Fennec.ReservationLog.name(base_name)
     r = Reservation.new(socket)
     :ok = Fennec.ReservationLog.register(rlog, r)
+    ## TODO: expire the reservation!
     r.token
   end
 

--- a/lib/fennec/evaluator/allocate/request.ex
+++ b/lib/fennec/evaluator/allocate/request.ex
@@ -87,7 +87,7 @@ defmodule Fennec.Evaluator.Allocate.Request do
     %{this_socket: nil,
       this_port: nil,
       new_reservation_token: nil,
-      retries: allocate_state.retries || @create_relays_max_retries}
+      retries: Map.get(allocate_state, :retries) || @create_relays_max_retries}
   end
 
   defp open_this_relay(_params, %{retries: r}, _server)

--- a/lib/fennec/reservation_log.ex
+++ b/lib/fennec/reservation_log.ex
@@ -1,0 +1,44 @@
+defmodule Fennec.ReservationLog do
+  @moduledoc false
+
+  ## Runtime support for storing and fetching pending reservations.
+  ## I.e. an ETS table owner process.
+
+  alias Fennec.TURN.Reservation
+  alias Jerboa.Format.Body.Attribute.ReservationToken
+
+  @type name :: atom
+
+  def start_link(base_name) do
+    name = __MODULE__.name(base_name)
+    Agent.start_link(fn -> init_db(name) end, name: name)
+  end
+
+  @spec register(name, Reservation.t) :: :ok | {:error, :exists}
+  def register(name, %Reservation{} = r) do
+    case :ets.insert_new(name, {r.token.value, r}) do
+      false -> {:error, :exists}
+      _ -> :ok
+    end
+  end
+
+  @spec take(name, ReservationToken.t) :: Reservation.t | nil
+  def take(name, %ReservationToken{} = token) do
+    case :ets.take(name, token.value) do
+      [] -> nil
+      [r] -> r
+    end
+  end
+
+  @spec name(name) :: name
+  def name(base_name) do
+    "#{base_name}.ReservationLog" |> String.to_atom()
+  end
+
+  defp init_db(table_name) do
+    ## TODO: largely guesswork here, not load tested
+    perf_opts = [write_concurrency: true]
+    ^table_name = :ets.new(table_name, [:public, :named_table] ++ perf_opts)
+  end
+
+end

--- a/lib/fennec/reservation_log.ex
+++ b/lib/fennec/reservation_log.ex
@@ -16,7 +16,7 @@ defmodule Fennec.ReservationLog do
 
   @spec register(name, Reservation.t) :: :ok | {:error, :exists}
   def register(name, %Reservation{} = r) do
-    case :ets.insert_new(name, {r.token.value, r}) do
+    case :ets.insert_new(name, Reservation.to_tuple(r)) do
       false -> {:error, :exists}
       _ -> :ok
     end
@@ -26,7 +26,7 @@ defmodule Fennec.ReservationLog do
   def take(name, %ReservationToken{} = token) do
     case :ets.take(name, token.value) do
       [] -> nil
-      [r] -> r
+      [r] -> Reservation.from_tuple(r)
     end
   end
 

--- a/lib/fennec/turn/reservation.ex
+++ b/lib/fennec/turn/reservation.ex
@@ -26,14 +26,12 @@ defmodule Fennec.TURN.Reservation do
                 socket: socket}
   end
 
-  @doc false
   ## Only intended for storing in ETS
   def to_tuple(%__MODULE__{} = r) do
     %__MODULE__{token: %ReservationToken{value: token}} = r
     {token, r.socket}
   end
 
-  @doc false
   ## Only intended for storing in ETS
   def from_tuple({token, socket}) when is_binary(token) and is_port(socket) do
     %__MODULE__{token: %ReservationToken{value: token},

--- a/lib/fennec/turn/reservation.ex
+++ b/lib/fennec/turn/reservation.ex
@@ -1,4 +1,4 @@
-defmodule Reservation do
+defmodule Fennec.TURN.Reservation do
   @moduledoc false
 
   ## A Reservation represents a relay address reserved
@@ -23,6 +23,20 @@ defmodule Reservation do
   @spec new(Fennec.UDP.socket) :: t
   def new(socket) do
     %__MODULE__{token: ReservationToken.new(),
+                socket: socket}
+  end
+
+  @doc false
+  ## Only intended for storing in ETS
+  def to_tuple(%__MODULE__{} = r) do
+    %__MODULE__{token: %ReservationToken{value: token}} = r
+    {token, r.socket}
+  end
+
+  @doc false
+  ## Only intended for storing in ETS
+  def from_tuple({token, socket}) when is_binary(token) and is_port(socket) do
+    %__MODULE__{token: %ReservationToken{value: token},
                 socket: socket}
   end
 

--- a/lib/fennec/turn/reservation.ex
+++ b/lib/fennec/turn/reservation.ex
@@ -1,0 +1,29 @@
+defmodule Reservation do
+  @moduledoc false
+
+  ## A Reservation represents a relay address reserved
+  ## by an allocation request with a positive `EvenPort.reserved?`.
+  ## The relay address is created along with a RESERVATION-TOKEN
+  ## which is returned to the client requesting the allocation,
+  ## and is stored until another allocation request with the same
+  ## reservation token is sent by the client.
+  ## The Reservation is then turned into a full-blown Allocation.
+  ## This mechanism is used to allocate consecutive port pairs,
+  ## for example for RTP and RTCP transmissions.
+
+  alias Jerboa.Format.Body.Attribute.ReservationToken
+
+  defstruct [:token, :socket]
+
+  @type t :: %__MODULE__{
+    token: ReservationToken.t,
+    socket: Fennec.UDP.socket
+  }
+
+  @spec new(Fennec.UDP.socket) :: t
+  def new(socket) do
+    %__MODULE__{token: ReservationToken.new(),
+                socket: socket}
+  end
+
+end

--- a/lib/fennec/turn/reservation.ex
+++ b/lib/fennec/turn/reservation.ex
@@ -40,18 +40,4 @@ defmodule Fennec.TURN.Reservation do
                 socket: socket}
   end
 
-  @doc false
-  ## Only intended for storing in ETS
-  def to_tuple(%__MODULE__{} = r) do
-    %__MODULE__{token: %ReservationToken{value: token}} = r
-    {token, r.socket}
-  end
-
-  @doc false
-  ## Only intended for storing in ETS
-  def from_tuple({token, socket}) when is_binary(token) and is_port(socket) do
-    %__MODULE__{token: %ReservationToken{value: token},
-                socket: socket}
-  end
-
 end

--- a/lib/fennec/turn/reservation.ex
+++ b/lib/fennec/turn/reservation.ex
@@ -40,4 +40,18 @@ defmodule Fennec.TURN.Reservation do
                 socket: socket}
   end
 
+  @doc false
+  ## Only intended for storing in ETS
+  def to_tuple(%__MODULE__{} = r) do
+    %__MODULE__{token: %ReservationToken{value: token}} = r
+    {token, r.socket}
+  end
+
+  @doc false
+  ## Only intended for storing in ETS
+  def from_tuple({token, socket}) when is_binary(token) and is_port(socket) do
+    %__MODULE__{token: %ReservationToken{value: token},
+                socket: socket}
+  end
+
 end

--- a/lib/fennec/udp/receiver.ex
+++ b/lib/fennec/udp/receiver.ex
@@ -27,8 +27,9 @@ defmodule Fennec.UDP.Receiver do
   end
 
   def handle_info({:udp, socket, ip, port, data}, %{socket: socket} = state) do
-    _ = Fennec.UDP.Dispatcher.dispatch(state.dispatcher, state.worker_sup,
-                                       socket, ip, port, data)
+    ## TODO: refactor to a proper struct?
+    client = %{socket: socket, ip: ip, port: port}
+    _ = Fennec.UDP.Dispatcher.dispatch(state.dispatcher, state.worker_sup, client, data)
     {:noreply, state}
   end
 end

--- a/lib/fennec/udp/receiver.ex
+++ b/lib/fennec/udp/receiver.ex
@@ -28,7 +28,7 @@ defmodule Fennec.UDP.Receiver do
 
   def handle_info({:udp, socket, ip, port, data}, %{socket: socket} = state) do
     _ = Fennec.UDP.Dispatcher.dispatch(state.dispatcher, state.worker_sup,
-      state.socket, ip, port, data)
+                                       socket, ip, port, data)
     {:noreply, state}
   end
 end

--- a/lib/fennec/udp/supervisor.ex
+++ b/lib/fennec/udp/supervisor.ex
@@ -12,6 +12,7 @@ defmodule Fennec.UDP.Supervisor do
     children = [
       supervisor(Fennec.UDP.Dispatcher, [base_name]),
       supervisor(Fennec.UDP.WorkerSupervisor, [base_name, opts]),
+      worker(Fennec.ReservationLog, [base_name]),
       worker(Fennec.UDP.Receiver, [base_name, opts])
     ]
 

--- a/lib/fennec/udp/supervisor.ex
+++ b/lib/fennec/udp/supervisor.ex
@@ -12,7 +12,6 @@ defmodule Fennec.UDP.Supervisor do
     children = [
       supervisor(Fennec.UDP.Dispatcher, [base_name]),
       supervisor(Fennec.UDP.WorkerSupervisor, [base_name, opts]),
-      worker(Fennec.ReservationLog, [base_name]),
       worker(Fennec.UDP.Receiver, [base_name, opts])
     ]
 

--- a/lib/fennec/udp/worker_supervisor.ex
+++ b/lib/fennec/udp/worker_supervisor.ex
@@ -19,9 +19,9 @@ defmodule Fennec.UDP.WorkerSupervisor do
   end
 
   # Starts worker under WorkerSupervisor
-  @spec start_worker(atom, UDP.socket, Fennec.ip, Fennec.portn) :: {:ok, pid} | :error
-  def start_worker(worker_sup, socket, ip, port) do
-    case Supervisor.start_child(worker_sup, [socket, ip, port]) do
+  @spec start_worker(atom, Fennec.client_info) :: {:ok, pid} | :error
+  def start_worker(worker_sup, client) do
+    case Supervisor.start_child(worker_sup, [client]) do
       {:ok, pid} ->
         {:ok, pid}
       _ ->

--- a/mix.lock
+++ b/mix.lock
@@ -9,7 +9,7 @@
   "hackney": {:hex, :hackney, "1.7.1", "e238c52c5df3c3b16ce613d3a51c7220a784d734879b1e231c9babd433ac1cb4", [:rebar3], [{:certifi, "1.0.0", [hex: :certifi, optional: false]}, {:idna, "4.0.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
   "idna": {:hex, :idna, "4.0.0", "10aaa9f79d0b12cf0def53038547855b91144f1bfcc0ec73494f38bb7b9c4961", [:rebar3], []},
   "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
-  "jerboa": {:git, "https://github.com/esl/jerboa.git", "625276d4f605352ea7da78a0bdca1e0dba7ce2d8", []},
+  "jerboa": {:git, "https://github.com/esl/jerboa.git", "10ce9603b559193e3bf537924e96648e92b70a42", []},
   "jsx": {:hex, :jsx, "2.8.2", "7acc7d785b5abe8a6e9adbde926a24e481f29956dd8b4df49e3e4e7bcc92a018", [:mix, :rebar3], []},
   "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:make, :rebar], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},

--- a/test/fennec/udp/allocate_test.exs
+++ b/test/fennec/udp/allocate_test.exs
@@ -164,6 +164,7 @@ defmodule Fennec.UDP.AllocateTest do
       ])
       %XORRelayedAddress{port: relay_port1} = Params.get_attr(params1, XORRelayedAddress)
       reservation_token = Params.get_attr(params1, ReservationToken)
+      IO.inspect(reservation_token, label: "\nreservation token")
       ## then the next allocation with a RESERVATION-TOKEN
       ## allocates a relay address with the reserved port
       udp2 = UDP.connect(addr, addr, 1)

--- a/test/fennec/udp/allocate_test.exs
+++ b/test/fennec/udp/allocate_test.exs
@@ -170,7 +170,7 @@ defmodule Fennec.UDP.AllocateTest do
       udp2 = UDP.connect(addr, addr, 1)
       on_exit fn -> UDP.close(udp2) end
       params2 = UDP.allocate(udp2, attributes: [reservation_token])
-      %XORRelayedAddress{port: relay_port2} = Params.get_attr(params1, XORRelayedAddress)
+      %XORRelayedAddress{port: relay_port2} = Params.get_attr(params2, XORRelayedAddress)
       assert Integer.is_even(relay_port1)
       assert relay_port2 == relay_port1 + 1
     end

--- a/test/fennec/udp/auth_template.ex
+++ b/test/fennec/udp/auth_template.ex
@@ -39,7 +39,7 @@ defmodule Fennec.UDP.AuthTemplate do
               :allocate   -> nil
               _           ->
                 quote do
-                  UDP.allocate(udp, username)
+                  UDP.allocate(udp, username: username)
                   UDP.create_permissions(udp, [{127,0,0,1}], username)
                 end
             end

--- a/test/fennec/udp/server_test.exs
+++ b/test/fennec/udp/server_test.exs
@@ -6,10 +6,11 @@ defmodule Fennec.UDP.ServerTest do
     {:ok, _} = Fennec.UDP.start(ip: {127, 0, 0, 1}, port: port)
 
     expected_name = String.to_atom(~s"Elixir.Fennec.UDP.#{port}")
-    assert [{^expected_name, _, _, _}] =
-      Supervisor.which_children(Fennec.Supervisor)
+    assert [{Fennec.ReservationLog, _, _, _}, {^expected_name, _, _, _}] =
+      Enum.sort(Supervisor.which_children(Fennec.Supervisor))
     assert :ok = Fennec.UDP.stop(port)
-    assert [] = Supervisor.which_children(Fennec.Supervisor)
+    assert [{Fennec.ReservationLog, _, _, _}] =
+      Supervisor.which_children(Fennec.Supervisor)
   end
 
   test "start/1 allows to start multiple servers on different ports" do

--- a/test/helper/udp.ex
+++ b/test/helper/udp.ex
@@ -75,13 +75,16 @@ defmodule Helper.UDP do
 
   ## UDP Client
 
-  def allocate(udp, username \\ @default_user, client_id \\ 0) do
+  def allocate(udp, opts \\ []) do
+    opts = Keyword.merge([username: @default_user,
+                          client_id: 0,
+                          attributes: []], opts)
     id = Params.generate_id()
-    req = allocate_request(id, [
+    req = allocate_request(id, opts[:attributes] ++ [
       %RequestedTransport{protocol: :udp},
-      %Username{value: username}
+      %Username{value: opts[:username]}
     ])
-    resp = no_auth(communicate(udp, client_id, req))
+    resp = no_auth(communicate(udp, opts[:client_id], req))
     params = Format.decode!(resp)
     %Params{class: :success,
             method: :allocate,


### PR DESCRIPTION
This might still need some polish / refactoring, but the happy path finally works, i.e. full support for EVEN-PORT and RESERVATION-TOKEN (both issuing by the server to mark a newly created reservation and consuming when sent by a client, to use a previously reserved port).

Open TODOs (only reservation expiration is crucial feature-wise):

```
lib/fennec/evaluator/allocate/request.ex:180:    ## TODO: expire the reservation!
lib/fennec/evaluator/allocate/request.ex:185:    ## TODO: {:active, true} is not an option for a production system!
lib/fennec/reservation_log.ex:35:    ## TODO: largely guesswork here, not load tested
lib/fennec/udp/receiver.ex:30:    ## TODO: refactor to a proper struct?
```

This addresses #22, #23.