### PR TITLE
Improve documentation before 0.2.0 release

### DIFF
--- a/lib/fennec.ex
+++ b/lib/fennec.ex
@@ -1,5 +1,5 @@
 defmodule Fennec do
-  @moduledoc """
+  @moduledoc ~S"""
   STUN/TURN servers
 
   Fennec allows you to start multiple listeners (later called "servers")
@@ -14,6 +14,15 @@ defmodule Fennec do
 
   Currently only UDP transport is supported. Read more about it in the documentation
   of `Fennec.UDP`.
+
+  ## Global configuration
+
+  The only parameter configured globally is a shared secret used for TURN
+  authentication:
+
+      config :fennec, secret: "my_secret"
+
+  Currently it is not possible to configure it per listening TURN port.
   """
 
   @type ip :: :inet.ip_address

--- a/lib/fennec/evaluator/refresh/request.ex
+++ b/lib/fennec/evaluator/refresh/request.ex
@@ -1,9 +1,7 @@
 defmodule Fennec.Evaluator.Refresh.Request do
-  @moduledoc """
-  Implements Refresh request as defined by [RFC 5766 Section 7: Refreshing an Allocation][rfc5766-sec7].
-
-  [rfc5766-sec7]: https://tools.ietf.org/html/rfc5766#section-7
-  """
+  @moduledoc false
+  # Implements Refresh request as defined by [RFC 5766 Section 7: Refreshing an Allocation][rfc5766-sec7].
+  # [rfc5766-sec7]: https://tools.ietf.org/html/rfc5766#section-7
 
   import Fennec.Evaluator.Helper, only: [maybe: 3]
   alias Fennec.{TURN, TURN.Allocation}

--- a/lib/fennec/helper.ex
+++ b/lib/fennec/helper.ex
@@ -1,8 +1,7 @@
 defmodule Fennec.Helper do
-  @moduledoc """
-  Helper module that defines some commonly used functions in order to make
-  code cleaner and testing easier.
-  """
+  @moduledoc false
+  # Helper module that defines some commonly used functions in order to make
+  # code cleaner and testing easier.
 
   import Kernel, except: [to_string: 1]
   defimpl String.Chars, for: Tuple do

--- a/lib/fennec/time.ex
+++ b/lib/fennec/time.ex
@@ -1,8 +1,7 @@
 defmodule Fennec.Time do
-  @moduledoc ~S"""
-  Abstract time(r)-related functions for mocking / overriding them in tests.
-  This should allow for testing timeouts without actually waiting.
-  """
+  @moduledoc false
+  # Abstract time(r)-related functions for mocking / overriding them in tests.
+  # This should allow for testing timeouts without actually waiting.
 
   @type seconds :: integer
 

--- a/lib/fennec/turn/reservation/instance.ex
+++ b/lib/fennec/turn/reservation/instance.ex
@@ -1,4 +1,6 @@
 defmodule Fennec.TURN.Reservation.Instance do
+  @moduledoc false
+
   use GenServer
 
   def init([registry, allocation_worker, reservation, timeout]) do


### PR DESCRIPTION
Set `@moduledoc false` where appropriate and mention configuration of TURN secret.